### PR TITLE
Update Slack references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The goal is to have a low-tech (static html from markdown) website, optimized fo
 
 Doing so would improve the SEO (Search Engine Optimization), and make the different components of the DSC ecosystem more discoverable by its potential users, by providing a portal.
 
-It is not meant to replace the [existing forums found on PowerShell.Org](https://powershell.org/forums/forum/dsc-desired-state-configuration/), the [instant messaging DSC channel on the PowerShell Slack](http://powershell.slack.com) ([go there for registration](http://slack.poshcode.org/)).
+It is not meant to replace the [existing forums found on PowerShell.Org](https://powershell.org/forums/forum/dsc-desired-state-configuration/), the [instant messaging DSC channel on the PowerShell Slack](http://powershell.slack.com).
 
 ## Production Website
 

--- a/config.toml
+++ b/config.toml
@@ -88,9 +88,9 @@ bgcolor = "#ffffff"
     [Languages.en.params.cta]
       enable = true
       title = "Didn't find an answer to your question?"
-      description = "Come on the PowerShell Slack, DSC Channel where you'll be able to find us!"
-      btnText = "contact us"
-      btnURL = "http://slack.poshcode.org/"
+      description = "Ask the question on the PowerShell #DSC channel where you'll be able to find us!"
+      btnText = "join the conversation"
+      btnURL = "community/contact/"
 
     # contact
     [Languages.en.params.contact]

--- a/content/Community/committee.en.md
+++ b/content/Community/committee.en.md
@@ -1,13 +1,14 @@
 ---
 title: "DSC Committee"
 date: 2019-01-29T11:02:05+06:00
+weight: 2
 type: "post"
 author: "gaelcolas"
 ---
 
 Here's an explanation of what the DSC Committee is attempting to help with, and how we're trying to help the community.
 
-[Come and chat to us](http://slack.poshcode.org) if you'd like to discuss how we can improve!
+[Come and chat with us](/community/contact/) if you'd like to discuss how we can improve!
 
 ## The Decision Process
 
@@ -37,4 +38,4 @@ The DSC Resource Kit was already operating under similar structure, but it wasn'
 
 **Daniel** has been a long time contributor to the DSC Resource Kit, and if you had anything to do on the GitHub repository, you most likely have came across his work. Not only he is maintaining a few High Quality Resource Module, he consistently produce a massive efforts to help review other Pull Request and improve the testing and quality of the Resource Kit.
 
-**Johan** is also a top contributor and maintains some of the most actives Resources, while joining Daniel in reviewing code across all other repositories and improving the experience and quality of the DSC Resource Kit. Johan also helps new contributors and maintainers to get up to speed, and any DSC user in the DSC channel of the PowerShell Slack team.
+**Johan** is also a top contributor and maintains some of the most actives Resources, while joining Daniel in reviewing code across all other repositories and improving the experience and quality of the DSC Resource Kit. Johan also helps new contributors and maintainers to get up to speed, and any DSC user in the [Slack PowerShell #DSC channel](/community/contact/).

--- a/content/Community/contact.en.md
+++ b/content/Community/contact.en.md
@@ -1,0 +1,29 @@
+---
+title: "Join the conversation"
+date: 2019-01-29T11:02:05+06:00
+weight: 3
+type: "post"
+author: "Johan Ljunggren"
+---
+
+The community gathers in the PowerShell #DSC channel which is an open
+forum for all DSC related questions, discussions and collaboration.
+
+The PowerShell channels is bridged between Discord and Slack, so you
+can use either respectively app or website.
+
+>*Tagging a specific user so they get notified works best in the app
+>that the user uses. Most maintainers and committee members has joined
+>through Slack.*
+
+There are not just the #DSC channel, there are a lot of other discussions
+around PowerShell in various channels. On top of the #DSC channel you can
+join any other channel as well.
+
+##### Slack
+
+Join trough Slack by using this short link: [j.mp/psslack](j.mp/psslack)
+
+##### Discord
+
+Join trough Discord using this short link: [j.mp/psdiscord](j.mp/psdiscord)

--- a/content/Community/contact.en.md
+++ b/content/Community/contact.en.md
@@ -22,7 +22,7 @@ join any other channel as well.
 
 ##### Slack
 
-Join trough Slack by using this short link: [j.mp/psslack](j.mp/psslack)
+Join trough Slack by using this short link: [j.mp/psslack](https://join.slack.com/t/powershell/shared_invite/enQtNjk2ODE4MTkxNTY4LWJlOTU3NzBiYWFiMjM3Mzg3M2E5OGJiNGE4YjVhODVlNWNlY2I2ZWRkNGY2NjE4MThiYTg4OWI5NjA4MDM3ZjQ)
 
 ##### Discord
 

--- a/content/Community/contact.en.md
+++ b/content/Community/contact.en.md
@@ -22,8 +22,8 @@ join any other channel as well.
 
 ##### Slack
 
-Join trough Slack by using this short link: [j.mp/psslack](https://join.slack.com/t/powershell/shared_invite/enQtNjk2ODE4MTkxNTY4LWJlOTU3NzBiYWFiMjM3Mzg3M2E5OGJiNGE4YjVhODVlNWNlY2I2ZWRkNGY2NjE4MThiYTg4OWI5NjA4MDM3ZjQ)
+Join through: <a href="https://join.slack.com/t/powershell/shared_invite/enQtNjk2ODE4MTkxNTY4LWJlOTU3NzBiYWFiMjM3Mzg3M2E5OGJiNGE4YjVhODVlNWNlY2I2ZWRkNGY2NjE4MThiYTg4OWI5NjA4MDM3ZjQ" target="_blank"><img src="https://img.shields.io/badge/Slack-PowerShell-blue.svg?style=flat&logo=Slack" alt="Join Slack" style="width:150px;padding-top: 12px;" /></a>
 
 ##### Discord
 
-Join trough Discord using this short link: [j.mp/psdiscord](j.mp/psdiscord)
+Join through: <a href=j.mp/psdiscord" target="_blank"><img src="https://img.shields.io/badge/Discord-PowerShell-blue.svg?style=flat&logo=Discord" alt="Join Slack" style="width:165px;padding-top: 12px;" /></a>

--- a/content/Community/ownership.en.md
+++ b/content/Community/ownership.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Ownership of DSC Resources"
 date: 2019-07-18T15:02:05+06:00
-weight: 0
+weight: 1
 type: "post"
 author: "gaelcolas"
 ---


### PR DESCRIPTION
Update Slack references since it is possible to register directly on the Slack website now. The old sign-up page links to that, and the old sign up page had issues (and hasn't been update).

I did not add Discord, but maybe we should do that, or should we have Slack as the primary way in (on the web page)?

*Testing sending in a PR to see what we are missing review-wise.*

Closes #6 
Closes #9