### PR TITLE
Psconf2020 DSC is Dead

### DIFF
--- a/content/blog/DSC-is-dead-long-live-dsc.en.md
+++ b/content/blog/DSC-is-dead-long-live-dsc.en.md
@@ -41,6 +41,6 @@ We wanted to clear up some misunderstanding, present the humans behind the [DSC 
 I hope that another time we will be able to introduce the [DSC Community Maintainers](/community/maintainers/), and show the awesome work they're doing, and how you can help them!
 
 If you still have unanswered questions, we would love to hear them.
-You'll find us on the PowerShell slack or Discord, in the DSC channel.
+You'll find us on the [PowerShell slack](https://aka.ms/psslack) or Discord, in the DSC channel.
 
 Check our [Help](/help/) for more info.

--- a/content/blog/DSC-is-dead-long-live-dsc.en.md
+++ b/content/blog/DSC-is-dead-long-live-dsc.en.md
@@ -1,0 +1,46 @@
+---
+title: "DSC is Dead"
+date: 2020-05-30T23:00:00+01:00
+type: "post"
+weight: 2
+draft: false
+author: gaelcolas
+---
+
+Hi PowerShell and DSC folks!
+
+I wanted to share the [PSConfEU](https://psconf.eu) session Michael and myself have recorded on DSC and Guest Configuration.
+
+There will be a live Q&A on the Wednesday 3rd of June at 6PM CEST (9AM Pacific Time), so make sure you have watched and [submit any further question](http://powershell.one/psconfeu/psconf.eu-2020/about#asking-questions-in-real-time).
+Tune-in as early as Tuesday 2nd of June 5PM CEST to [watch the live Opening and Keynote](http://powershell.one/psconfeu/psconf.eu-2020/about#june-2-2020) with Tobias, Jeffrey Snover and Joey Aiello.
+
+{{< youtube id="hXS-rzs3Hak" >}}
+
+Here's a quick table of content for this session:
+
+1. [From PowerShell to DSC](https://youtu.be/hXS-rzs3Hak?t=155)
+1. [MOF parsing one-liner](https://youtu.be/hXS-rzs3Hak?t=945) (Quick tip)
+1. [DevOps and Infrastructure as Code](https://youtu.be/hXS-rzs3Hak?t=1122)
+1. [Is DSC dead?](https://youtu.be/hXS-rzs3Hak?t=1627)
+1. [Invoke-DscResource in PS5 & PS7](https://youtu.be/hXS-rzs3Hak?t=1843)
+1. [The DSC Community](https://youtu.be/hXS-rzs3Hak?t=3083)
+    - [Katie](https://youtu.be/hXS-rzs3Hak?t=3215)
+    - [Dan](https://youtu.be/hXS-rzs3Hak?t=3353)
+    - [Johan](https://youtu.be/hXS-rzs3Hak?t=3448)
+1. [Guest Configuration](https://youtu.be/hXS-rzs3Hak?t=3695)
+1. [Azure Arc](https://youtu.be/hXS-rzs3Hak?t=4064)
+1. [Conclusion](https://youtu.be/hXS-rzs3Hak?t=4590)
+
+The main points we wanted to cover in this session are what the current situation was, answer some questions, and show you where the future might be.
+We know that if you're following what the DSC Community and maybe joined one of our Community call, you must have heard a good chunk.
+
+This is an attempt to address the questions we hear the most, regardless of your knowledge -or lack of- in the DSC technology, Configuration Management or Infrastructure as Code.
+
+We wanted to clear up some misunderstanding, present the humans behind the [DSC Community Committee](/community/committee/), and explain how the technology may relate to your job and your future. You can read more details about [the Origin Story online](/origin-story/).
+
+I hope that another time we will be able to introduce the [DSC Community Maintainers](/community/maintainers/), and show the awesome work they're doing, and how you can help them!
+
+If you still have unanswered questions, we would love to hear them.
+You'll find us on the PowerShell slack or Discord, in the DSC channel.
+
+Check our [Help](/help/) for more info.

--- a/content/help/_index.en.md
+++ b/content/help/_index.en.md
@@ -39,7 +39,7 @@ Make sure you check those resources and post your question on the forum if you c
 
 ### DSC Slack & Discord Instant Messaging
 
-<a href="http://slack.poshcode.org/" target="_blank"><img src="../images/appIcon_desktop.png" alt="Slack" style="width:100px; display:block; float: left; margin-left: auto;margin-right:auto; padding-right: 15px; border-radius:0%" /></a>
+<a href="https://aka.ms/psslack" target="_blank"><img src="../images/appIcon_desktop.png" alt="Slack" style="width:100px; display:block; float: left; margin-left: auto;margin-right:auto; padding-right: 15px; border-radius:0%" /></a>
 
 Some members of the community are very active in the DSC channel, of the PowerShell Slack.
 Join the conversation here if you want to meet the community, and ask questions.


### PR DESCRIPTION
Adding quick intro and TOC for DSC is dead video.
Took opportunity to update the slack links.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dsccommunity.org/140)
<!-- Reviewable:end -->
