### PR TITLE
Add option to insert GitHub API token for maintainers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,8 @@ steps:
   - pwsh: |
       .\hugo\hugo.exe --source "$(System.DefaultWorkingDirectory)" --destination "$(Build.ArtifactStagingDirectory)" --printI18nWarnings --printPathWarnings --logLevel info
     displayName: "Build Hugo Site"
+    env:
+      HUGO_GITHUB_TOKEN: $(GITHUB_TOKEN)
 
   - task: PublishPipelineArtifact@0
     displayName: "Publish Hugo site as artifact"

--- a/layouts/community/maintainers.html
+++ b/layouts/community/maintainers.html
@@ -62,7 +62,12 @@
           >
             {{ range sort $.Site.Data.maintainers "accountName" }} {{ $data :=
             dict }} {{ $path := printf "https://api.github.com/users/%s"
-            .accountName }} {{ with resources.GetRemote $path }} {{ with
+            .accountName }}
+            {{ $opts := dict }}
+            {{ with os.Getenv "HUGO_GITHUB_TOKEN" }}
+              {{ $opts = dict "headers" (dict "Authorization" (printf "token %s" .)) }}
+            {{ end }}
+            {{ with resources.GetRemote $path $opts }} {{ with
             .Content | transform.Unmarshal }} {{ $data = . }} {{ end }} {{ else
             }} {{ errorf "Unable to get global resource %q" $path }} {{ end }}
 


### PR DESCRIPTION
Adds support for authenticating GitHub API requests when fetching maintainer information to avoid rate limiting and 403 Forbidden errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dsccommunity.org/250)
<!-- Reviewable:end -->
