### PR TITLE
Add community notes February 2026

### DIFF
--- a/content/community_calls/2026-02-18 Notes.en.md
+++ b/content/community_calls/2026-02-18 Notes.en.md
@@ -1,0 +1,47 @@
+---
+title: "2026-02-18 Notes"
+weight: 968
+type: "post"
+date: 2026-02-18
+---
+
+### Recording
+
+{{< youtube id="Vbs2LK6oo-Q" >}}
+
+## Agenda
+
+#### Community presentation
+
+None
+
+#### Topics
+
+This call focused on recent DSC advancements, featuring live demos and
+discussions around tooling improvements and the DSC V3.2 roadmap.
+
+- **VS Code extension** (demo by Gijs): Improved DSC configuration
+  editing with IntelliSense, MOF-to-V3 conversion, and resource
+  manifest generation.
+- **DSC Bicep extension** (demo by Andy): Enables orchestration of DSC
+  resources using Bicep's local deploy feature, with type support and
+  dependency resolution. Future plans include publishing to official
+  registries.
+- **DSC V3.2 roadmap** (Steve): Quality-driven release timeline with a
+  planned Python adapter to broaden resource authoring beyond
+  PowerShell, and future consideration for languages like C#.
+- **Q&A highlights**: Clarified that Bicep handles orchestration and
+  type resolution when using the DSC extension; discussed user-defined
+  types and custom functions.
+- **Action items**: Test `ak.ms` links for extension distribution and open
+  the Bicep types project for community contributions.
+
+### DSC resource modules that have been released recently
+
+- Releases
+- Preview
+
+#### Tooling modules that have been released recently
+
+- Releases
+- Preview


### PR DESCRIPTION
This pull request adds the meeting notes for the February 2026 community call.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dsccommunity.org/251)
<!-- Reviewable:end -->
