### PR TITLE
Fix mobile menu display

### DIFF
--- a/assets/css/futuristic.css
+++ b/assets/css/futuristic.css
@@ -135,6 +135,7 @@
   /* Z-Index Scale */
   --z-dropdown: 100;
   --z-sticky: 200;
+  --z-nav-mobile: 250;
   --z-fixed: 300;
   --z-modal-backdrop: 400;
   --z-modal: 500;
@@ -408,7 +409,7 @@ pre code {
 .site-header {
   position: sticky;
   top: 0;
-  z-index: var(--z-sticky);
+  z-index: var(--z-fixed);
   background: var(--bg-primary);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -573,49 +574,251 @@ pre code {
   color: var(--text-primary);
 }
 
+/* Mobile Navigation */
+.mobile-menu {
+  display: none;
+}
+
 @media (max-width: 768px) {
   .main-nav {
-    position: fixed;
-    top: var(--header-height);
-    left: 0;
-    right: 0;
-    bottom: 0;
-    flex-direction: column;
-    align-items: stretch;
-    padding: var(--space-4);
-    background: var(--bg-primary);
-    border-top: 1px solid var(--border-color);
-    transform: translateX(-100%);
-    transition: transform var(--transition-normal);
-    overflow-y: auto;
-  }
-
-  .main-nav.open {
-    transform: translateX(0);
-  }
-
-  .nav-list {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .dropdown-menu {
-    position: static;
-    opacity: 1;
-    visibility: visible;
-    transform: none;
-    box-shadow: none;
-    border: none;
-    padding-left: var(--space-4);
     display: none;
   }
 
-  .nav-item.open .dropdown-menu {
-    display: block;
+  .menu-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
   }
 
-  .menu-toggle {
+  .menu-toggle:active,
+  .menu-toggle:hover {
+    background: var(--bg-tertiary);
+  }
+
+  .search-toggle {
+    min-width: 40px;
+    height: 40px;
+    justify-content: center;
+    padding: 0;
+    border-radius: var(--radius-md);
+  }
+
+  .search-toggle span,
+  .search-toggle kbd,
+  .header-actions > .theme-toggle {
+    display: none;
+  }
+
+  .mobile-menu {
     display: block;
+    position: fixed;
+    inset: 0;
+    z-index: var(--z-modal);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--transition-normal);
+  }
+
+  .mobile-menu.open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .mobile-menu-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.62);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+  }
+
+  .mobile-menu-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    width: min(92vw, 390px);
+    background: var(--bg-primary);
+    border-left: 1px solid var(--border-color);
+    box-shadow: -24px 0 80px rgba(0, 0, 0, 0.28);
+    transform: translateX(100%);
+    transition: transform 320ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .mobile-menu.open .mobile-menu-panel {
+    transform: translateX(0);
+  }
+
+  .mobile-menu-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-5) var(--space-5) var(--space-4);
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .mobile-menu-eyebrow {
+    display: block;
+    margin-bottom: var(--space-1);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    color: var(--color-primary);
+    text-transform: uppercase;
+  }
+
+  .mobile-menu-title {
+    margin: 0;
+    font-size: var(--text-2xl);
+    line-height: 1.1;
+    color: var(--text-primary);
+  }
+
+  .mobile-menu-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    cursor: pointer;
+  }
+
+  .mobile-menu-close i {
+    font-size: 22px;
+    line-height: 1;
+  }
+
+  .mobile-menu-body {
+    min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: var(--space-4) var(--space-4) var(--space-6);
+  }
+
+  .mobile-menu-list {
+    display: grid;
+    gap: var(--space-3);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .mobile-menu-link,
+  .mobile-menu-heading,
+  .mobile-submenu-link {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+    min-height: 48px;
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+
+  .mobile-menu-link,
+  .mobile-menu-heading {
+    padding: var(--space-3);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    background: var(--bg-secondary);
+    font-size: var(--text-base);
+    font-weight: 700;
+  }
+
+  .mobile-menu-link.active,
+  .mobile-menu-link:active,
+  .mobile-menu-link:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  .mobile-menu-icon,
+  .mobile-submenu-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-md);
+    background: var(--gradient-accent);
+    color: #fff;
+    flex: 0 0 auto;
+  }
+
+  .mobile-menu-group {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .mobile-submenu {
+    display: grid;
+    gap: var(--space-2);
+    padding-left: var(--space-4);
+  }
+
+  .mobile-submenu-link {
+    min-height: 44px;
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .mobile-submenu-link:active,
+  .mobile-submenu-link:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+
+  .mobile-submenu-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: var(--radius-sm);
+  }
+
+  .mobile-menu-footer {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border-top: 1px solid var(--border-color);
+    background: var(--bg-primary);
+  }
+
+  .mobile-menu-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    min-height: 44px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .mobile-menu-action:hover,
+  .mobile-menu-action:active {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+    text-decoration: none;
   }
 }
 
@@ -1201,7 +1404,10 @@ pre code {
   margin-bottom: var(--space-4);
 }
 
-[data-theme="dark"] .timeline-year-header,
+[data-theme="dark"] .timeline-year-header {
+  background: var(--bg-primary);
+}
+
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) .timeline-year-header {
     background: var(--bg-primary);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -56,18 +56,12 @@ function setTheme(theme) {
 }
 
 function updateThemeToggle(theme) {
-  const sunIcon = document.querySelector(".sun-icon");
-  const moonIcon = document.querySelector(".moon-icon");
-
-  if (sunIcon && moonIcon) {
-    if (theme === "dark") {
-      sunIcon.style.display = "none";
-      moonIcon.style.display = "block";
-    } else {
-      sunIcon.style.display = "block";
-      moonIcon.style.display = "none";
-    }
-  }
+  document.querySelectorAll(".sun-icon, .sun-icon-panel").forEach((el) => {
+    el.style.display = theme === "dark" ? "none" : "block";
+  });
+  document.querySelectorAll(".moon-icon, .moon-icon-panel").forEach((el) => {
+    el.style.display = theme === "dark" ? "block" : "none";
+  });
 }
 
 function toggleTheme() {
@@ -110,16 +104,39 @@ function initHeader() {
  * Mobile Menu
  */
 function toggleMobileMenu() {
-  const nav = document.getElementById("mainNav");
+  const menu = document.getElementById("mobileMenu");
   const toggle = document.getElementById("menuToggle");
+  if (!menu || !toggle) return;
 
-  if (nav && toggle) {
-    nav.classList.toggle("open");
-    toggle.setAttribute("aria-expanded", nav.classList.contains("open"));
-  }
+  const isOpen = menu.classList.toggle("open");
+  toggle.setAttribute("aria-expanded", String(isOpen));
+  menu.setAttribute("aria-hidden", String(!isOpen));
+  document.body.style.overflow = isOpen ? "hidden" : "";
 }
 
+function closeMobileMenu() {
+  const menu = document.getElementById("mobileMenu");
+  const toggle = document.getElementById("menuToggle");
+  if (!menu || !menu.classList.contains("open")) return;
+
+  menu.classList.remove("open");
+  menu.setAttribute("aria-hidden", "true");
+  toggle && toggle.setAttribute("aria-expanded", "false");
+  document.body.style.overflow = "";
+}
+
+document.addEventListener("click", (e) => {
+  const mobileLink = e.target.closest(".mobile-menu a[href]");
+  if (mobileLink) closeMobileMenu();
+});
+
+// Close on Escape
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") closeMobileMenu();
+});
+
 window.toggleMobileMenu = toggleMobileMenu;
+window.closeMobileMenu = closeMobileMenu;
 
 /**
  * Search Modal

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,20 @@
+[mobileMenuOpenAriaLabel]
+other = "Open menu"
+
+[mobileNavigationAriaLabel]
+other = "Mobile navigation"
+
+[mobileMenuTitle]
+other = "Menu"
+
+[mobileMenuCloseAriaLabel]
+other = "Close menu"
+
+[themeToggleAriaLabel]
+other = "Toggle dark mode"
+
+[theme]
+other = "Theme"
+
+[github]
+other = "GitHub"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,0 +1,20 @@
+[mobileMenuOpenAriaLabel]
+other = "Ouvrir le menu"
+
+[mobileNavigationAriaLabel]
+other = "Navigation mobile"
+
+[mobileMenuTitle]
+other = "Menu"
+
+[mobileMenuCloseAriaLabel]
+other = "Fermer le menu"
+
+[themeToggleAriaLabel]
+other = "Activer ou désactiver le mode sombre"
+
+[theme]
+other = "Thème"
+
+[github]
+other = "GitHub"

--- a/layouts/partials/header-new.html
+++ b/layouts/partials/header-new.html
@@ -173,7 +173,8 @@
         <button
           class="menu-toggle"
           id="menuToggle"
-          aria-label="Toggle menu"
+          aria-label="Open menu"
+          aria-expanded="false"
           onclick="toggleMobileMenu()"
         >
           <svg
@@ -185,8 +186,8 @@
             stroke-linecap="round"
             stroke-linejoin="round"
           >
-            <line x1="4" x2="20" y1="12" y2="12" />
             <line x1="4" x2="20" y1="6" y2="6" />
+            <line x1="4" x2="20" y1="12" y2="12" />
             <line x1="4" x2="20" y1="18" y2="18" />
           </svg>
         </button>
@@ -194,3 +195,86 @@
     </div>
   </div>
 </header>
+
+<!-- Mobile Navigation -->
+<div class="mobile-menu" id="mobileMenu" aria-hidden="true">
+  <div class="mobile-menu-backdrop" onclick="closeMobileMenu()"></div>
+  <aside class="mobile-menu-panel" role="dialog" aria-modal="true" aria-label="Mobile navigation">
+    <div class="mobile-menu-header">
+      <div>
+        <span class="mobile-menu-eyebrow">DSC Community</span>
+        <h2 class="mobile-menu-title">Menu</h2>
+      </div>
+      <button class="mobile-menu-close" onclick="closeMobileMenu()" aria-label="Close menu">
+        <i class="ri-close-line"></i>
+      </button>
+    </div>
+
+    <div class="mobile-menu-body">
+      <ul class="mobile-menu-list">
+        {{ range .Site.Menus.main }}
+        {{ if .HasChildren }}
+        <li class="mobile-menu-group">
+          <span class="mobile-menu-heading">
+            <span class="mobile-menu-icon"><i class="ri-folder-3-line"></i></span>
+            <span>{{ .Name }}</span>
+          </span>
+          <div class="mobile-submenu">
+            {{ range .Children }}
+            <a href="{{ .URL }}" class="mobile-submenu-link">
+              <span class="mobile-submenu-icon">
+                {{ if eq .Name "Community" }}
+                <i class="ri-team-line"></i>
+                {{ else if eq .Name "Resource Modules" }}
+                <i class="ri-apps-2-line"></i>
+                {{ else if eq .Name "Guidelines" }}
+                <i class="ri-book-open-line"></i>
+                {{ else if eq .Name "Blog Posts" }}
+                <i class="ri-article-line"></i>
+                {{ else if eq .Name "Config. Management" }}
+                <i class="ri-settings-3-line"></i>
+                {{ else }}
+                <i class="ri-file-text-line"></i>
+                {{ end }}
+              </span>
+              <span>{{ .Name }}</span>
+            </a>
+            {{ end }}
+          </div>
+        </li>
+        {{ else }}
+        <li>
+          <a href="{{ .URL }}" class="mobile-menu-link{{ if eq $.RelPermalink .URL }} active{{ end }}">
+            <span class="mobile-menu-icon">
+              {{ if eq .Name "Code of Conduct" }}
+              <i class="ri-shield-check-line"></i>
+              {{ else if eq .Name "Community Calls" }}
+              <i class="ri-calendar-event-line"></i>
+              {{ else if eq .Name "FAQ" }}
+              <i class="ri-question-answer-line"></i>
+              {{ else if eq .Name "Help" }}
+              <i class="ri-lifebuoy-line"></i>
+              {{ else }}
+              <i class="ri-file-list-line"></i>
+              {{ end }}
+            </span>
+            <span>{{ .Name }}</span>
+          </a>
+        </li>
+        {{ end }}
+        {{ end }}
+      </ul>
+    </div>
+
+    <div class="mobile-menu-footer">
+      <button class="mobile-menu-action" onclick="toggleTheme()" aria-label="Toggle dark mode">
+        <i class="ri-contrast-2-line"></i>
+        <span>Theme</span>
+      </button>
+      <a href="https://github.com/dsccommunity" class="mobile-menu-action" target="_blank" rel="noopener noreferrer">
+        <i class="ri-github-fill"></i>
+        <span>GitHub</span>
+      </a>
+    </div>
+  </aside>
+</div>

--- a/layouts/partials/header-new.html
+++ b/layouts/partials/header-new.html
@@ -117,7 +117,7 @@
         <button
           class="theme-toggle"
           id="themeToggle"
-          aria-label="Toggle dark mode"
+          aria-label="{{ i18n "themeToggleAriaLabel" }}"
           onclick="toggleTheme()"
         >
           <svg
@@ -154,7 +154,7 @@
         <a
           href="https://github.com/dsccommunity"
           class="theme-toggle"
-          aria-label="GitHub"
+          aria-label="{{ i18n "github" }}"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -173,7 +173,7 @@
         <button
           class="menu-toggle"
           id="menuToggle"
-          aria-label="Open menu"
+          aria-label="{{ i18n "mobileMenuOpenAriaLabel" }}"
           aria-expanded="false"
           onclick="toggleMobileMenu()"
         >
@@ -199,13 +199,13 @@
 <!-- Mobile Navigation -->
 <div class="mobile-menu" id="mobileMenu" aria-hidden="true">
   <div class="mobile-menu-backdrop" onclick="closeMobileMenu()"></div>
-  <aside class="mobile-menu-panel" role="dialog" aria-modal="true" aria-label="Mobile navigation">
+  <aside class="mobile-menu-panel" role="dialog" aria-modal="true" aria-label="{{ i18n "mobileNavigationAriaLabel" }}">
     <div class="mobile-menu-header">
       <div>
-        <span class="mobile-menu-eyebrow">DSC Community</span>
-        <h2 class="mobile-menu-title">Menu</h2>
+        <span class="mobile-menu-eyebrow">{{ .Site.Title }}</span>
+        <h2 class="mobile-menu-title">{{ i18n "mobileMenuTitle" }}</h2>
       </div>
-      <button class="mobile-menu-close" onclick="closeMobileMenu()" aria-label="Close menu">
+      <button class="mobile-menu-close" onclick="closeMobileMenu()" aria-label="{{ i18n "mobileMenuCloseAriaLabel" }}">
         <i class="ri-close-line"></i>
       </button>
     </div>
@@ -267,13 +267,13 @@
     </div>
 
     <div class="mobile-menu-footer">
-      <button class="mobile-menu-action" onclick="toggleTheme()" aria-label="Toggle dark mode">
+      <button class="mobile-menu-action" onclick="toggleTheme()" aria-label="{{ i18n "themeToggleAriaLabel" }}">
         <i class="ri-contrast-2-line"></i>
-        <span>Theme</span>
+        <span>{{ i18n "theme" }}</span>
       </button>
       <a href="https://github.com/dsccommunity" class="mobile-menu-action" target="_blank" rel="noopener noreferrer">
         <i class="ri-github-fill"></i>
-        <span>GitHub</span>
+        <span>{{ i18n "github" }}</span>
       </a>
     </div>
   </aside>


### PR DESCRIPTION
Updates the mobile menu so all navigation options are visible and easy to select. The menu now opens in a clearer mobile-friendly layout, includes the full list of links, and closes when selecting a link, tapping outside the menu, or pressing Escape.

What was shown before:

<img width="607" height="1184" alt="image" src="https://github.com/user-attachments/assets/510448a1-0953-41f8-a8aa-0c9df4e14b1a" />

(whilst pressing the menu, it overlayed totally incorrectly).

To what it is with this change:

<img width="607" height="1184" alt="image" src="https://github.com/user-attachments/assets/01354783-6cc7-4ecd-a006-fd47d3f91194" />


Also fixes a page styling issue that could affect how the menu and other styles are displayed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dsccommunity.org/255)
<!-- Reviewable:end -->
