### PR TITLE
Update `/blog/` section

### DIFF
--- a/assets/css/futuristic.css
+++ b/assets/css/futuristic.css
@@ -928,6 +928,10 @@ pre code {
   pointer-events: none;
 }
 
+.hero-compact {
+  padding: var(--space-16) 0;
+}
+
 .hero::after {
   content: "";
   position: absolute;
@@ -1291,9 +1295,16 @@ pre code {
   height: 100%;
 }
 
+.blog-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+  gap: var(--space-6);
+}
+
 .blog-card-meta {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-3);
   margin-bottom: var(--space-3);
   font-size: var(--text-sm);
@@ -1309,6 +1320,21 @@ pre code {
   color: var(--color-primary);
 }
 
+.blog-card-tag-microsoft {
+  background: rgba(0, 120, 212, 0.1);
+  color: #0078d4;
+}
+
+.blog-card-tag-powershell {
+  background: rgba(0, 173, 239, 0.1);
+  color: #0078a8;
+}
+
+.blog-card-tag-community {
+  background: rgba(16, 185, 129, 0.1);
+  color: #047857;
+}
+
 .blog-card-title {
   font-size: var(--text-lg);
   margin-bottom: var(--space-3);
@@ -1321,14 +1347,32 @@ pre code {
   font-size: var(--text-sm);
 }
 
+.blog-card-footer {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-top: auto;
+  padding-top: var(--space-5);
+}
+
+.blog-card-reading-time {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
 .blog-card-read-more {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  margin-top: var(--space-4);
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--color-primary);
+  white-space: nowrap;
 }
 
 .blog-card-read-more svg {
@@ -2157,6 +2201,65 @@ pre code {
 /* -----------------------------------------------------------------------------
    Blog Section Headers (list page)
    ----------------------------------------------------------------------------- */
+.blog-index-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-4);
+  margin-bottom: var(--space-16);
+}
+
+.blog-index-summary-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  min-height: 72px;
+  padding: var(--space-5);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--color-primary);
+  border-radius: var(--radius-lg);
+  color: inherit;
+  text-decoration: none;
+  transition: all var(--transition-normal);
+}
+
+.blog-index-summary-item:hover {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-md);
+  text-decoration: none;
+  transform: translateY(-2px);
+}
+
+.blog-index-summary-item span {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.blog-index-summary-item strong {
+  color: var(--text-primary);
+  font-size: var(--text-2xl);
+  line-height: 1;
+}
+
+.blog-index-summary-item-microsoft {
+  border-left-color: #0078d4;
+}
+
+.blog-index-summary-item-powershell {
+  border-left-color: #0078a8;
+}
+
+.blog-index-summary-item-community {
+  border-left-color: #047857;
+}
+
+.blog-section {
+  margin-bottom: var(--space-16);
+  scroll-margin-top: calc(var(--header-height) + var(--space-6));
+}
+
 .blog-section-header {
   display: flex;
   align-items: flex-start;
@@ -2179,6 +2282,18 @@ pre code {
   margin-top: 2px;
 }
 
+.blog-section-icon-microsoft {
+  background: linear-gradient(135deg, #0078d4 0%, #00bcf2 100%);
+}
+
+.blog-section-icon-powershell {
+  background: linear-gradient(135deg, #012456 0%, #00adef 100%);
+}
+
+.blog-section-icon-community {
+  background: linear-gradient(135deg, #047857 0%, #10b981 100%);
+}
+
 .blog-section-title {
   font-size: var(--text-2xl);
   font-weight: 700;
@@ -2190,6 +2305,19 @@ pre code {
   color: var(--text-secondary);
   font-size: var(--text-sm);
   margin: 0;
+}
+
+@media (max-width: 768px) {
+  .blog-index-summary {
+    grid-template-columns: 1fr;
+    margin-bottom: var(--space-12);
+  }
+
+  .blog-card-footer {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
 }
 
 .search-result-item:hover,

--- a/content/blog/_index.en.md
+++ b/content/blog/_index.en.md
@@ -3,14 +3,15 @@ title: "Blog Posts"
 date: 2018-12-29T11:02:05+06:00
 icon: "ti-rss-alt"
 weight: 4
-description: "Blog from the maintainers, Contributors and guests"
-type : "pages"
+description: "Blog from the maintainers, contributors, and guests"
 bgcolor: '#00B7C3'
 ---
 
 ## Blog with us
 
 Hi, this is where our blogged content is made available.
-Feel free to send us your content of stuff using or related with DSC! Just submit a Pull request to the Website under the `/content/blog/` section.
+Feel free to send us your content of stuff using or related with DSC! Just submit
+a Pull request to the Website under the `/content/blog/` section.
 
-Please make sure **the name of the file contains the language** such as `mycontent.en.md` for an article written in English.
+Please make sure **the name of the file contains the language** such as
+`mycontent.en.md` for an article written in English.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html
-  lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}"
+  lang="{{ with .Site.Language.Locale }}{{ . }}{{ else }}en-US{{ end }}"
   data-theme="light"
 >
   <head>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,7 +1,6 @@
 {{ define "main" }}
 
-<!-- Page Header -->
-<section class="hero" style="padding: var(--space-16) 0;">
+<section class="hero hero-compact">
   <div class="hero-grid"></div>
   <div class="container">
     <div class="hero-content">
@@ -11,46 +10,58 @@
       </span>
       <h1 class="hero-title">Blog Posts</h1>
       <p class="hero-description">
-        Insights, tutorials, and updates from the DSC Community maintainers and contributors. Learn best practices, explore new features, and stay up to date.
+        Insights, tutorials, and updates from DSC Community maintainers and contributors.
       </p>
     </div>
   </div>
 </section>
 
-<!-- Blog Sections -->
 <section class="section">
   <div class="container">
-
     {{ $allPages := .Data.Pages.ByDate.Reverse }}
-    {{ $msftPages := where $allPages ".Params.dsc_family" "Microsoft DSC" }}
-    {{ $psPages := where $allPages ".Params.dsc_family" "PowerShell DSC" }}
-    {{ $communityPages := where $allPages ".Params.dsc_family" "Community" }}
-    {{ $uncategorized := where $allPages ".Params.dsc_family" "" }}
+    {{ $microsoftPages := where $allPages "Params.dsc_family" "Microsoft DSC" }}
+    {{ $powerShellPages := where $allPages "Params.dsc_family" "PowerShell DSC" }}
+    {{ $otherPages := where $allPages "Params.dsc_family" "not in" (slice "Microsoft DSC" "PowerShell DSC") }}
+    {{ $sections := slice
+      (dict "title" "Microsoft DSC" "description" "Articles about Microsoft's cross-platform DSC tool" "icon" "ri-microsoft-line" "class" "microsoft" "pages" $microsoftPages)
+      (dict "title" "PowerShell DSC" "description" "Articles covering PowerShell Desired State Configuration" "icon" "ri-terminal-box-line" "class" "powershell" "pages" $powerShellPages)
+      (dict "title" "Community" "description" "News, guides, and how-to articles from the DSC Community" "icon" "ri-community-line" "class" "community" "pages" $otherPages)
+    }}
 
-    <!-- Microsoft DSC Section -->
-    {{ if gt (len $msftPages) 0 }}
-    <div class="blog-section" style="margin-bottom: var(--space-16);">
+    <div class="blog-index-summary" aria-label="Blog article groups">
+      {{ range $sections }}
+      <a href="#{{ .title | urlize }}" class="blog-index-summary-item blog-index-summary-item-{{ .class }}">
+        <span>{{ .title }}</span>
+        <strong>{{ len .pages }}</strong>
+      </a>
+      {{ end }}
+    </div>
+
+    {{ range $sections }}
+    {{ if gt (len .pages) 0 }}
+    {{ $section := . }}
+    <section class="blog-section" id="{{ .title | urlize }}" aria-labelledby="{{ .title | urlize }}-heading">
       <div class="blog-section-header">
-        <span class="blog-section-icon" style="background: linear-gradient(135deg, #0078d4 0%, #00bcf2 100%);">
-          <i class="ri-microsoft-line"></i>
+        <span class="blog-section-icon blog-section-icon-{{ .class }}">
+          <i class="{{ .icon }}"></i>
         </span>
         <div>
-          <h2 class="blog-section-title">Microsoft DSC</h2>
-          <p class="blog-section-description">Articles about Microsoft's cross-platform DSC (v3) tool</p>
+          <h2 class="blog-section-title" id="{{ .title | urlize }}-heading">{{ .title }}</h2>
+          <p class="blog-section-description">{{ .description }}</p>
         </div>
       </div>
-      <div class="grid-auto stagger">
-        {{ range $msftPages }}
-        <a href="{{ .Permalink }}" class="card blog-card card-link">
+      <div class="blog-card-grid">
+        {{ range .pages }}
+        <a href="{{ .Permalink }}" class="card blog-card card-link blog-card-{{ $section.class }}">
           <div class="blog-card-meta">
-            <span class="blog-card-tag" style="background: rgba(0,120,212,0.1); color: #0078d4;">Microsoft DSC</span>
+            <span class="blog-card-tag blog-card-tag-{{ $section.class }}">{{ $section.title }}</span>
             <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
           </div>
           <h3 class="blog-card-title">{{ .Title }}</h3>
-          <p class="blog-card-excerpt">{{ .Summary | truncate 150 }}</p>
-          <div style="margin-top: auto;">
+          <p class="blog-card-excerpt">{{ .Summary | plainify | truncate 150 }}</p>
+          <div class="blog-card-footer">
             {{ if .ReadingTime }}
-            <span style="font-size: var(--text-xs); color: var(--text-tertiary); display: flex; align-items: center; gap: var(--space-1);">
+            <span class="blog-card-reading-time">
               <i class="ri-time-line"></i>
               {{ .ReadingTime }} min read
             </span>
@@ -63,89 +74,10 @@
         </a>
         {{ end }}
       </div>
-    </div>
+    </section>
+    {{ end }}
     {{ end }}
 
-    <!-- PowerShell DSC Section -->
-    {{ if gt (len $psPages) 0 }}
-    <div class="blog-section" style="margin-bottom: var(--space-16);">
-      <div class="blog-section-header">
-        <span class="blog-section-icon" style="background: linear-gradient(135deg, #012456 0%, #00adef 100%);">
-          <i class="ri-terminal-box-line"></i>
-        </span>
-        <div>
-          <h2 class="blog-section-title">PowerShell DSC</h2>
-          <p class="blog-section-description">Articles covering PowerShell Desired State Configuration</p>
-        </div>
-      </div>
-      <div class="grid-auto stagger">
-        {{ range $psPages }}
-        <a href="{{ .Permalink }}" class="card blog-card card-link">
-          <div class="blog-card-meta">
-            <span class="blog-card-tag" style="background: rgba(0,173,239,0.1); color: #00adef;">PowerShell DSC</span>
-            <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
-          </div>
-          <h3 class="blog-card-title">{{ .Title }}</h3>
-          <p class="blog-card-excerpt">{{ .Summary | truncate 150 }}</p>
-          <div style="margin-top: auto;">
-            {{ if .ReadingTime }}
-            <span style="font-size: var(--text-xs); color: var(--text-tertiary); display: flex; align-items: center; gap: var(--space-1);">
-              <i class="ri-time-line"></i>
-              {{ .ReadingTime }} min read
-            </span>
-            {{ end }}
-            <span class="blog-card-read-more">
-              Read article
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-            </span>
-          </div>
-        </a>
-        {{ end }}
-      </div>
-    </div>
-    {{ end }}
-
-    <!-- Community Section -->
-    {{ $generalPages := $communityPages | append $uncategorized }}
-    {{ if gt (len $generalPages) 0 }}
-    <div class="blog-section" style="margin-bottom: var(--space-16);">
-      <div class="blog-section-header">
-        <span class="blog-section-icon" style="background: linear-gradient(135deg, #7c3aed 0%, #a78bfa 100%);">
-          <i class="ri-community-line"></i>
-        </span>
-        <div>
-          <h2 class="blog-section-title">Community</h2>
-          <p class="blog-section-description">News, guides, and how-tos from the DSC Community</p>
-        </div>
-      </div>
-      <div class="grid-auto stagger">
-        {{ range $generalPages }}
-        <a href="{{ .Permalink }}" class="card blog-card card-link">
-          <div class="blog-card-meta">
-            <span class="blog-card-tag">Community</span>
-            <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
-          </div>
-          <h3 class="blog-card-title">{{ .Title }}</h3>
-          <p class="blog-card-excerpt">{{ .Summary | truncate 150 }}</p>
-          <div style="margin-top: auto;">
-            {{ if .ReadingTime }}
-            <span style="font-size: var(--text-xs); color: var(--text-tertiary); display: flex; align-items: center; gap: var(--space-1);">
-              <i class="ri-time-line"></i>
-              {{ .ReadingTime }} min read
-            </span>
-            {{ end }}
-            <span class="blog-card-read-more">
-              Read article
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-            </span>
-          </div>
-        </a>
-        {{ end }}
-      </div>
-    </div>
-    {{ end }}
-
-    <!-- Empty State -->
     {{ if eq (len .Data.Pages) 0 }}
     <div class="text-center" style="padding: var(--space-16) 0;">
       <i class="ri-article-line" style="font-size: 4rem; color: var(--text-tertiary);"></i>
@@ -156,7 +88,6 @@
   </div>
 </section>
 
-<!-- CTA Section -->
 <section class="section section-alt">
   <div class="container">
     <div class="cta">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -60,7 +60,11 @@
     </div>
 
     <div class="grid-auto stagger">
-      {{ range (where .Site.Pages "Type" "pages") }}
+      {{ $featurePages := where .Site.Pages "Type" "pages" }}
+      {{ with .Site.GetPage "section" "blog" }}
+      {{ $featurePages = $featurePages | append . }}
+      {{ end }}
+      {{ range $featurePages.ByWeight }}
       <a href="{{ .Permalink }}" class="card feature-card card-link">
         <div class="card-icon">
           {{ if eq .Params.Icon "ti-user" }}

--- a/themes/dot/layouts/_default/baseof.html
+++ b/themes/dot/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
+<html lang="{{ with .Site.Language.Locale }}{{ . }}{{ else }}en-US{{ end }}">
     {{- partial "head.html" . -}}
     <body>
         {{ if .IsHome }}


### PR DESCRIPTION
Somehow, the changes from #253 weren't applied correctly. This changes the `/blog` section to the following:

<img width="2560" height="1271" alt="image" src="https://github.com/user-attachments/assets/5b5ee0b0-f7fd-4be0-9817-0d2c04ca3a45" />

Also small fix on deprecated features after Hugo update.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dsccommunity.org/260)
<!-- Reviewable:end -->
